### PR TITLE
Rework selection mode

### DIFF
--- a/demo/src/jsMain/kotlin/tableDemo.kt
+++ b/demo/src/jsMain/kotlin/tableDemo.kt
@@ -145,7 +145,7 @@ fun RenderContext.tableDemo(): Div {
         componentFrame {
             lineUp {
                 items {
-                    TableComponent.Companion.SelectionMode.values().toList().map { mode ->
+                    TableComponent.Companion.SelectionMode.values().map { mode ->
                         clickButton { text(mode.toString()) }.events.map { mode } handledBy selectionModeStore.update
                     }
                 }
@@ -157,95 +157,96 @@ fun RenderContext.tableDemo(): Div {
         }
 
 
+        selectionModeStore.data.render {
+            table(rowIdProvider = Person::id) {
+                caption(selectionModeStore.data.map { mode ->
+                    "Table with \"${mode.name}\" Selection Mode "
+                })
+                tableStore(TableStore)
+                selectedRows(selectedStore.data)
+                selectedAllRowEvents = selectedStore.update
+                selectedRowEvent = selectedStore.toggle
+                selectionMode(selectionModeStore.current)
 
-        table<Person, Int>(rowIdProvider = Person::id) {
-            caption(selectionModeStore.data.map { mode ->
-                "Table with \"${mode.name}\" Selection Mode "
-            })
-            tableStore(TableStore)
-            selectedRows(selectedStore.data)
-            selectedAllRowEvents = selectedStore.update
-            selectedRowEvent = selectedStore.toggle
-            selectionMode(selectionModeStore.data)
-
-            defaultThStyle {
-                {
-                    background { color { "#1fd257" } }
-                }
-            }
-
-            columns {
-                column("ID") {
-                    lens { personIdLens + Formats.intFormat }
-                    width { minmax { "80px" } }
-                }
-                column("Name") {
-                    lens { fullNameLens }
-                    width { minmax { "1.33fr" } }
-                }
-                column("Birthday") {
-                    lens { birthdayLens + Formats.dateFormat }
-                    width { minmax { "120px" } }
-                    styling {
-                        color { danger }
-                    }
-                    sortBy {
-                        compareBy { person ->
-                            person.birthday
-                        }
+                defaultThStyle {
+                    {
+                        background { color { "#1fd257" } }
                     }
                 }
-                column {
-                    // lens can be omitted! It's purely optional and totally ok to have columns that hide its relation to
-                    // the data from the table itself!
-                    // ``header`` oder ``head``?
-                    header {
-                        title { "Address" }
+
+                columns {
+                    column("ID") {
+                        lens { personIdLens + Formats.intFormat }
+                        width { minmax { "80px" } }
+                    }
+                    column("Name") {
+                        lens { fullNameLens }
+                        width { minmax { "1.33fr" } }
+                    }
+                    column("Birthday") {
+                        lens { birthdayLens + Formats.dateFormat }
+                        width { minmax { "120px" } }
                         styling {
-                            background { color { "purple" } }
-                            fontWeight { bold }
+                            color { danger }
                         }
-                        content { config ->
-                            +config.headerName
-                            icon { fromTheme { fritz2 } }
-                        }
-                    }
-                    width { max { "2fr" } }
-                    content { ctx, _, rowStore ->
-                        rowStore?.let { person ->
-                            val street = person.sub(personAddressLens + streetLens)
-                            val houseNumber = person.sub(personAddressLens + houseNumberLens)
-                            val postalCode = person.sub(personAddressLens + postalCodeLens)
-                            val city = person.sub(personAddressLens + cityLens)
-                            ctx.apply {
-                                street.data.combine(houseNumber.data) { s, h ->
-                                    "$s $h"
-                                }.combine(postalCode.data) { a, p ->
-                                    "$a ,$p"
-                                }.combine(city.data) { a, c ->
-                                    "$a $c"
-                                }.asText()
+                        sortBy {
+                            compareBy { person ->
+                                person.birthday
                             }
+                        }
+                    }
+                    column {
+                        // lens can be omitted! It's purely optional and totally ok to have columns that hide its relation to
+                        // the data from the table itself!
+                        // ``header`` oder ``head``?
+                        header {
+                            title { "Address" }
+                            styling {
+                                background { color { "purple" } }
+                                fontWeight { bold }
+                            }
+                            content { config ->
+                                +config.headerName
+                                icon { fromTheme { fritz2 } }
+                            }
+                        }
+                        width { max { "2fr" } }
+                        content { ctx, _, rowStore ->
+                            rowStore?.let { person ->
+                                val street = person.sub(personAddressLens + streetLens)
+                                val houseNumber = person.sub(personAddressLens + houseNumberLens)
+                                val postalCode = person.sub(personAddressLens + postalCodeLens)
+                                val city = person.sub(personAddressLens + cityLens)
+                                ctx.apply {
+                                    street.data.combine(houseNumber.data) { s, h ->
+                                        "$s $h"
+                                    }.combine(postalCode.data) { a, p ->
+                                        "$a ,$p"
+                                    }.combine(city.data) { a, c ->
+                                        "$a $c"
+                                    }.asText()
+                                }
 
+                            }
+                        }
+                        sortBy {
+                            compareBy<Person> { person ->
+                                person.address.city
+                            }.thenBy { person ->
+                                person.address.street
+                            }
                         }
                     }
-                    sortBy {
-                        compareBy<Person> { person ->
-                            person.address.city
-                        }.thenBy { person ->
-                            person.address.street
-                        }
+                    column("Phone") {
+                        lens { phoneLens }
+                        // TODO: Ugly -> Enum must be receiver; but how?
+                        sorting { TableComponent.Companion.Sorting.DISABLED }
                     }
+                    column("Mobile") { lens { mobileLens } }
+                    column("E-Mail") { lens { emailLens } }
                 }
-                column("Phone") {
-                    lens { phoneLens }
-                    // TODO: Ugly -> Enum must be receiver; but how?
-                    sorting { TableComponent.Companion.Sorting.DISABLED }
-                }
-                column("Mobile") { lens { mobileLens } }
-                column("E-Mail") { lens { emailLens } }
+                sorter = NaiveSorter()
             }
-            sorter = NaiveSorter()
         }
     }
 }


### PR DESCRIPTION
- make selection mode _static_
- reduce complexity for handling with selections for 99% use cases
- user has to manage dynamic changes and re-render the whole table if mode needs to change dynamically (should be very seldom). But that's as simple as wrapping the ``table`` factory function call inside a render based upon the store or modes - so very low ceremony, but much reduced internal concerns while rendering the table