### PR TITLE
Implement MenuComponent

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ ext["fritz2Version"] = "0.9.1"
 allprojects {
     //manage common setting and dependencies
     repositories {
-        // mavenLocal()
+        mavenLocal()
         mavenCentral()
         maven("https://dl.bintray.com/kotlin/kotlin-dev")
         maven("https://dl.bintray.com/kotlin/kotlin-eap")
@@ -18,7 +18,7 @@ allprojects {
 
 subprojects {
     group = "dev.fritz2"
-    version = "0.9.1"
+    version = "0.10-SNAPSHOT"
 }
 
 tasks.dokkaHtmlMultiModule.configure {

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -84,16 +84,16 @@ fun main() {
                         text("Test")
                     }
                 }
-                placement { right }
+                placement { bottom }
                 items {
-                    menuCheckboxGroup(
+                    checkboxMenuGroup(
                         title = "Checkboxes",
                         options = listOf("Option 1", "Option 2", "Option 3")
                     )
 
                     menuDivider()
 
-                    menuRadioGroup(
+                    radioMenuGroup(
                         title = "Radios",
                         options = listOf("Option 1", "Option 2", "Option 3")
                     )
@@ -104,6 +104,8 @@ fun main() {
                         leftIcon { ban }
                         label("This is a simple menu-item.")
                     } handledBy menuClickStore.log
+
+                    menuDivider()
 
                     menuGroup {
                         title("Menu-Group")

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -115,7 +115,7 @@ fun main() {
 
     val enableDelayedFlow = flow<Boolean> {
         emit(false)
-        delay(5000L)
+        delay(4000)
         emit(true)
     }
 
@@ -147,12 +147,12 @@ fun main() {
                     subheader("Some more items:")
                     item {
                         icon { circleInformation }
-                        text("This item is disabled")
+                        text("Disabled")
                         enabled(false)
                     }
                     item {
                         icon { clock }
-                        text("This item is enabled after a couple of seconds")
+                        text("Enabled after a couple of seconds")
                         enabled(enableDelayedFlow)
                     }
                     divider()

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -75,11 +75,11 @@ fun main() {
         h1 { +"fritz incubator - Demo" }
         div {
             menu {
-                toggle {
+                /*toggle {
                     pushButton {
                         text("Test")
                     }
-                }
+                }*/
                 placement { bottom }
                 items {
                     item {

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -74,10 +74,6 @@ fun main() {
     render("#target") {
         h1 { +"fritz incubator - Demo" }
         div {
-            val menuClickStore = object : RootStore<Unit>(Unit) {
-                val log = handle<Unit> { _, _ -> console.log("Menu item clicked!") }
-            }
-
             menu {
                 toggle {
                     pushButton {
@@ -86,27 +82,11 @@ fun main() {
                 }
                 placement { bottom }
                 items {
-                    checkboxMenuGroup(
-                        title = "Checkboxes",
-                        options = listOf("Option 1", "Option 2", "Option 3")
-                    )
-
-                    menuDivider()
-
-                    radioMenuGroup(
-                        title = "Radios",
-                        options = listOf("Option 1", "Option 2", "Option 3")
-                    )
-
-                    menuDivider()
-
                     menuItem {
                         leftIcon { ban }
                         label("This is a simple menu-item.")
-                    } handledBy menuClickStore.log
-
+                    }
                     menuDivider()
-
                     menuGroup {
                         title("Menu-Group")
                         items {
@@ -120,6 +100,16 @@ fun main() {
                             }
                         }
                     }
+                    menuDivider()
+                    checkboxMenuGroup(
+                        title = "Checkboxes",
+                        options = listOf("Option 1", "Option 2", "Option 3")
+                    )
+                    menuDivider()
+                    radioMenuGroup(
+                        title = "Radios",
+                        options = listOf("Option 1", "Option 2", "Option 3")
+                    )
                 }
             }
         }

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -136,7 +136,7 @@ fun main() {
                         text(clickCounterStore.data.map { "Click-counter: $it" })
                     }
                 }
-                placement { bottom }
+                placement { right }
                 entries {
                     item {
                         icon { add }
@@ -163,7 +163,19 @@ fun main() {
                         )
                     }
                     custom {
-                        spinner { }
+                        menu {
+                            toggle {
+                                pushButton {
+                                    variant { outline }
+                                    text("Submenu")
+                                }
+                            }
+                            entries {
+                                item {
+                                    text("Submenu item")
+                                }
+                            }
+                        }
                     }
                     divider()
                     subheader("Custom MenuEntryContext")

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -123,7 +123,7 @@ fun main() {
         h1 { +"fritz incubator - Demo" }
         div {
             menu {
-                items {
+                entries {
                     item {
                         text("Test")
                     }
@@ -137,7 +137,7 @@ fun main() {
                     }
                 }
                 placement { bottom }
-                items {
+                entries {
                     item {
                         icon { add }
                         text("Increment the click-counter")

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -4,9 +4,10 @@ import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.P
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.dom.html.render
-import dev.fritz2.styling.params.plus
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.theme.Theme
+import kotlinx.coroutines.flow.map
+import org.w3c.dom.events.MouseEvent
 
 fun RenderContext.showcaseHeader(text: String) {
     (::h1.styled {
@@ -71,32 +72,37 @@ fun RenderContext.contentFrame(init: Div.() -> Unit): Div {
 
 fun main() {
 
+    val clickCounterStore = object : RootStore<Int>(0) {
+        val increment = handle<MouseEvent> { current, _ -> current + 1 }
+    }
+
     render("#target") {
         h1 { +"fritz incubator - Demo" }
         div {
             menu {
-                /*toggle {
+                toggle {
                     pushButton {
-                        text("Test")
+                        text(clickCounterStore.data.map { "Click-counter: $it" })
                     }
-                }*/
+                }
                 placement { bottom }
                 items {
                     item {
-                        leftIcon { ban }
-                        text("This is a simple menu-item.")
-                    }
+                        leftIcon { add }
+                        text("Increment the click-counter")
+                    } handledBy clickCounterStore.increment
+
                     divider()
                     subheader {
-                        text("This is a sub-header")
+                        text("Here are some more, unrelated items:")
                     }
                     item {
-                        leftIcon { link }
-                        text("Menu-item in a group.")
+                        leftIcon { circleInformation }
+                        text("Info")
                     }
                     item {
-                        leftIcon { camera }
-                        text("Menu-item in a group 2.")
+                        leftIcon { circleHelp }
+                        text("Help")
                     }
                     divider()
                     subheader("Custom menu entries:")

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -4,6 +4,8 @@ import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.P
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.dom.html.render
+import dev.fritz2.styling.StyleClass
+import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.theme.Theme
 import kotlinx.coroutines.flow.map
@@ -70,6 +72,34 @@ fun RenderContext.contentFrame(init: Div.() -> Unit): Div {
     }
 }
 
+
+class MyCustomEntriesContext : MenuEntriesContext() {
+
+    class RadioGroupContext {
+        val items = ComponentProperty(listOf<String>())
+
+        fun build() = object : MenuEntry {
+            override fun render(
+                context: RenderContext,
+                styling: BoxParams.() -> Unit,
+                baseClass: StyleClass,
+                id: String?,
+                prefix: String
+            ) {
+                context.apply {
+                    radioGroup(items = items.value)
+                }
+            }
+        }
+    }
+
+    fun radios(expression: RadioGroupContext.() -> Unit) = RadioGroupContext()
+        .apply(expression)
+        .build()
+        .also(::addEntry)
+}
+
+
 fun main() {
 
     val clickCounterStore = object : RootStore<Int>(0) {
@@ -79,7 +109,7 @@ fun main() {
     render("#target") {
         h1 { +"fritz incubator - Demo" }
         div {
-            menu {
+            menu(entriesContextProvider = { MyCustomEntriesContext() }) {
                 toggle {
                     pushButton {
                         text(clickCounterStore.data.map { "Click-counter: $it" })
@@ -93,9 +123,7 @@ fun main() {
                     } handledBy clickCounterStore.increment
 
                     divider()
-                    subheader {
-                        text("Here are some more, unrelated items:")
-                    }
+                    subheader("Here are some more, unrelated items:")
                     item {
                         leftIcon { circleInformation }
                         text("Info")
@@ -114,6 +142,11 @@ fun main() {
                     custom {
                         spinner { }
                     }
+                    divider()
+                    subheader("Items from a custom MenuEntryContext")
+                    radios {
+                        items(listOf("Item 1", "Item 2", "Item 3"))
+                    }
                 }
             }
         }
@@ -121,6 +154,7 @@ fun main() {
         tableDemo()
     }
 }
+
 
 fun title(s: String) {
 

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -8,6 +8,8 @@ import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.theme.Theme
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import org.w3c.dom.events.MouseEvent
 
@@ -111,6 +113,12 @@ fun main() {
         val increment = handle<MouseEvent> { current, _ -> current + 1 }
     }
 
+    val enableDelayedFlow = flow<Boolean> {
+        emit(false)
+        delay(5000L)
+        emit(true)
+    }
+
     render("#target") {
         h1 { +"fritz incubator - Demo" }
         div {
@@ -131,19 +139,21 @@ fun main() {
                 placement { bottom }
                 items {
                     item {
-                        leftIcon { add }
+                        icon { add }
                         text("Increment the click-counter")
                     } handledBy clickCounterStore.increment
 
                     divider()
                     subheader("Some more items:")
                     item {
-                        leftIcon { circleInformation }
-                        text("Info")
+                        icon { circleInformation }
+                        text("This item is disabled")
+                        enabled(false)
                     }
                     item {
-                        leftIcon { circleHelp }
-                        text("Help")
+                        icon { clock }
+                        text("This item is enabled after a couple of seconds")
+                        enabled(enableDelayedFlow)
                     }
                     divider()
                     subheader("Custom menu entries:")

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -1,7 +1,10 @@
+import dev.fritz2.binding.RootStore
+import dev.fritz2.components.*
 import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.P
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.dom.html.render
+import dev.fritz2.styling.params.plus
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.theme.Theme
 
@@ -71,6 +74,54 @@ fun main() {
     render("#target") {
         h1 { +"fritz incubator - Demo" }
         div {
+            val menuClickStore = object : RootStore<Unit>(Unit) {
+                val log = handle<Unit> { _, _ -> console.log("Menu item clicked!") }
+            }
+
+            flexBox({
+                width { "100%" }
+                direction { row }
+            }) {
+                clickButton {
+                    text("Test")
+                } handledBy menu {
+                    items {
+                        menuCheckboxGroup(
+                            title = "Checkboxes",
+                            options = listOf("Option 1", "Option 2", "Option 3")
+                        )
+
+                        menuDivider()
+
+                        menuRadioGroup(
+                            title = "Radios",
+                            options = listOf("Option 1", "Option 2", "Option 3")
+                        )
+
+                        menuDivider()
+
+                        menuItem {
+                            leftIcon { ban }
+                            label("This is a simple menu-item.")
+                        } handledBy menuClickStore.log
+
+                        menuGroup {
+                            title("Menu-Group")
+                            items {
+                                menuItem {
+                                    leftIcon { link }
+                                    label("Menu-item in a group.")
+                                }
+                                menuItem {
+                                    leftIcon { camera }
+                                    label("Menu-item in a group 2.")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             tableDemo()
         }
     }

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -84,6 +84,7 @@ fun main() {
                         text("Test")
                     }
                 }
+                placement { right }
                 items {
                     menuCheckboxGroup(
                         title = "Checkboxes",

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -82,38 +82,40 @@ fun main() {
                 }
                 placement { bottom }
                 items {
-                    menuItem {
+                    item {
                         leftIcon { ban }
-                        label("This is a simple menu-item.")
+                        text("This is a simple menu-item.")
                     }
-                    menuDivider()
-                    menuGroup {
-                        title("Menu-Group")
-                        items {
-                            menuItem {
-                                leftIcon { link }
-                                label("Menu-item in a group.")
-                            }
-                            menuItem {
-                                leftIcon { camera }
-                                label("Menu-item in a group 2.")
-                            }
-                        }
+                    divider()
+                    subheader {
+                        text("This is a sub-header")
                     }
-                    menuDivider()
+                    item {
+                        leftIcon { link }
+                        text("Menu-item in a group.")
+                    }
+                    item {
+                        leftIcon { camera }
+                        text("Menu-item in a group 2.")
+                    }
+                    /*divider()
                     checkboxMenuGroup(
                         title = "Checkboxes",
                         options = listOf("Option 1", "Option 2", "Option 3")
                     )
-                    menuDivider()
+                    divider()
                     radioMenuGroup(
                         title = "Radios",
                         options = listOf("Option 1", "Option 2", "Option 3")
-                    )
+                    )*/
                 }
             }
         }
 
         tableDemo()
     }
+}
+
+fun title(s: String) {
+
 }

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -87,7 +87,12 @@ class MyCustomEntriesContext : MenuEntriesContext() {
                 prefix: String
             ) {
                 context.apply {
-                    radioGroup(items = items.value)
+                    radioGroup(items = items.value, styling = {
+                        margins {
+                            horizontal { small }
+                            vertical { smaller }
+                        }
+                    })
                 }
             }
         }
@@ -123,7 +128,7 @@ fun main() {
                     } handledBy clickCounterStore.increment
 
                     divider()
-                    subheader("Here are some more, unrelated items:")
+                    subheader("Some more items:")
                     item {
                         leftIcon { circleInformation }
                         text("Info")
@@ -143,7 +148,7 @@ fun main() {
                         spinner { }
                     }
                     divider()
-                    subheader("Items from a custom MenuEntryContext")
+                    subheader("Custom MenuEntryContext")
                     radios {
                         items(listOf("Item 1", "Item 2", "Item 3"))
                     }

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -98,16 +98,16 @@ fun main() {
                         leftIcon { camera }
                         text("Menu-item in a group 2.")
                     }
-                    /*divider()
-                    checkboxMenuGroup(
-                        title = "Checkboxes",
-                        options = listOf("Option 1", "Option 2", "Option 3")
-                    )
                     divider()
-                    radioMenuGroup(
-                        title = "Radios",
-                        options = listOf("Option 1", "Option 2", "Option 3")
-                    )*/
+                    subheader("Custom menu entries:")
+                    custom {
+                        checkboxGroup(
+                            items = listOf("Item 1", "Item 2")
+                        )
+                    }
+                    custom {
+                        spinner { }
+                    }
                 }
             }
         }

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -174,6 +174,24 @@ fun main() {
                             }
                         }
                     }
+                    custom {
+                        popover {
+                            toggle {
+                                pushButton {
+                                    variant { outline }
+                                    text("Spawn a popover")
+                                }
+                            }
+                            placement { right }
+                            content {
+                                box {
+                                    p {
+                                        +"This is a popover with a very long text."
+                                    }
+                                }
+                            }
+                        }
+                    }
                     divider()
                     subheader("Custom MenuEntryContext")
                     radios {

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -78,52 +78,49 @@ fun main() {
                 val log = handle<Unit> { _, _ -> console.log("Menu item clicked!") }
             }
 
-            flexBox({
-                width { "100%" }
-                direction { row }
-            }) {
-                clickButton {
-                    text("Test")
-                } handledBy menu {
-                    items {
-                        menuCheckboxGroup(
-                            title = "Checkboxes",
-                            options = listOf("Option 1", "Option 2", "Option 3")
-                        )
+            menu {
+                toggle {
+                    pushButton {
+                        text("Test")
+                    }
+                }
+                items {
+                    menuCheckboxGroup(
+                        title = "Checkboxes",
+                        options = listOf("Option 1", "Option 2", "Option 3")
+                    )
 
-                        menuDivider()
+                    menuDivider()
 
-                        menuRadioGroup(
-                            title = "Radios",
-                            options = listOf("Option 1", "Option 2", "Option 3")
-                        )
+                    menuRadioGroup(
+                        title = "Radios",
+                        options = listOf("Option 1", "Option 2", "Option 3")
+                    )
 
-                        menuDivider()
+                    menuDivider()
 
-                        menuItem {
-                            leftIcon { ban }
-                            label("This is a simple menu-item.")
-                        } handledBy menuClickStore.log
+                    menuItem {
+                        leftIcon { ban }
+                        label("This is a simple menu-item.")
+                    } handledBy menuClickStore.log
 
-                        menuGroup {
-                            title("Menu-Group")
-                            items {
-                                menuItem {
-                                    leftIcon { link }
-                                    label("Menu-item in a group.")
-                                }
-                                menuItem {
-                                    leftIcon { camera }
-                                    label("Menu-item in a group 2.")
-                                }
+                    menuGroup {
+                        title("Menu-Group")
+                        items {
+                            menuItem {
+                                leftIcon { link }
+                                label("Menu-item in a group.")
+                            }
+                            menuItem {
+                                leftIcon { camera }
+                                label("Menu-item in a group 2.")
                             }
                         }
                     }
                 }
             }
-
-            tableDemo()
         }
-    }
 
+        tableDemo()
+    }
 }

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -114,6 +114,14 @@ fun main() {
     render("#target") {
         h1 { +"fritz incubator - Demo" }
         div {
+            menu {
+                items {
+                    item {
+                        text("Test")
+                    }
+                }
+            }
+
             menu(entriesContextProvider = { MyCustomEntriesContext() }) {
                 toggle {
                     pushButton {

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -10,6 +10,7 @@ import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.theme.Theme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import org.w3c.dom.events.MouseEvent
 
@@ -78,7 +79,7 @@ fun RenderContext.contentFrame(init: Div.() -> Unit): Div {
 class RadioGroupContext {
     val items = ComponentProperty(listOf<String>())
 
-    fun build() = object : MenuEntry {
+    fun build() = object : MenuEntryComponent {
         override fun render(
             context: RenderContext,
             styling: BoxParams.() -> Unit,
@@ -144,7 +145,7 @@ fun main() {
                     item {
                         icon { circleInformation }
                         text("Disabled")
-                        enabled(false)
+                        enabled(flowOf(false))
                     }
                     item {
                         icon { clock }

--- a/demo/src/jsMain/kotlin/app.kt
+++ b/demo/src/jsMain/kotlin/app.kt
@@ -75,36 +75,33 @@ fun RenderContext.contentFrame(init: Div.() -> Unit): Div {
 }
 
 
-class MyCustomEntriesContext : MenuEntriesContext() {
+class RadioGroupContext {
+    val items = ComponentProperty(listOf<String>())
 
-    class RadioGroupContext {
-        val items = ComponentProperty(listOf<String>())
-
-        fun build() = object : MenuEntry {
-            override fun render(
-                context: RenderContext,
-                styling: BoxParams.() -> Unit,
-                baseClass: StyleClass,
-                id: String?,
-                prefix: String
-            ) {
-                context.apply {
-                    radioGroup(items = items.value, styling = {
-                        margins {
-                            horizontal { small }
-                            vertical { smaller }
-                        }
-                    })
-                }
+    fun build() = object : MenuEntry {
+        override fun render(
+            context: RenderContext,
+            styling: BoxParams.() -> Unit,
+            baseClass: StyleClass,
+            id: String?,
+            prefix: String
+        ) {
+            context.apply {
+                radioGroup(items = items.value, styling = {
+                    margins {
+                        horizontal { small }
+                        vertical { smaller }
+                    }
+                })
             }
         }
     }
-
-    fun radios(expression: RadioGroupContext.() -> Unit) = RadioGroupContext()
-        .apply(expression)
-        .build()
-        .also(::addEntry)
 }
+
+fun MenuEntriesContext.radios(expression: RadioGroupContext.() -> Unit) = RadioGroupContext()
+    .apply(expression)
+    .build()
+    .run(::addEntry)
 
 
 fun main() {
@@ -130,13 +127,12 @@ fun main() {
                 }
             }
 
-            menu(entriesContextProvider = { MyCustomEntriesContext() }) {
+            menu {
                 toggle {
                     pushButton {
                         text(clickCounterStore.data.map { "Click-counter: $it" })
                     }
                 }
-                placement { right }
                 entries {
                     item {
                         icon { add }
@@ -170,6 +166,7 @@ fun main() {
                                     text("Submenu")
                                 }
                             }
+                            placement { right }
                             entries {
                                 item {
                                     text("Submenu item")

--- a/menu/build.gradle.kts
+++ b/menu/build.gradle.kts
@@ -1,9 +1,26 @@
 plugins {
     kotlin("multiplatform")
+    id("maven-publish")
+    id("org.jetbrains.dokka")
+}
+
+repositories {
+    mavenLocal()
 }
 
 kotlin {
-    js().browser()
+    jvm()
+    js(BOTH).browser {
+        testTask {
+            useKarma {
+//                useSafari()
+//                useFirefox()
+//                useChrome()
+                useChromeHeadless()
+//                usePhantomJS()
+            }
+        }
+    }
     sourceSets {
         all {
             languageSettings.apply {
@@ -18,10 +35,7 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                implementation(project(":datatable"))
-                implementation(project(":menu"))
                 implementation("dev.fritz2:components:${rootProject.ext["fritz2Version"]}")
-                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.1.0")
             }
         }
 
@@ -40,6 +54,26 @@ kotlin {
         val jsTest by getting {
             dependencies {
                 implementation(kotlin("test-js"))
+            }
+        }
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "bintray"
+            val releaseUrl = "https://api.bintray.com/maven/jwstegemann/fritz2/${project.name}/;" +
+                    "publish=0;" + // Never auto-publish to allow override.
+                    "override=1"
+            val snapshotUrl = "https://oss.jfrog.org/artifactory/oss-snapshot-local"
+            val isRelease = System.getenv("GITHUB_EVENT_NAME").equals("release", true)
+
+            url = uri(if (isRelease && !version.toString().endsWith("SNAPSHOT")) releaseUrl else snapshotUrl)
+
+            credentials {
+                username = "jwstegemann"
+                password = System.getenv("BINTRAY_API_KEY")
             }
         }
     }

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -212,34 +212,30 @@ interface MenuEntry : Component<Unit>
 
 class MenuEntriesContext {
 
-    private interface MenuEntryContext {
-        fun build(): MenuEntry
-    }
-
-    class ItemContext : MenuEntryContext {
+    class ItemContext {
         val leftIcon = ComponentProperty<(Icons.() -> IconDefinition)?>(value = null)
         val text = ComponentProperty("")
         val rightIcon = ComponentProperty<(Icons.() -> IconDefinition)?>(value = null)
 
-        override fun build() = MenuItem(
+        fun build() = MenuItem(
             leftIcon.value?.invoke((Theme().icons)),
             text.value,
             rightIcon.value?.invoke(Theme().icons)
         )
     }
 
-    class CustomContentContext : MenuEntryContext {
+    class CustomContentContext {
         val content = ComponentProperty<RenderContext.() -> Unit> { }
-        override fun build(): MenuEntry = MenuCustomContent(content.value)
+        fun build() = MenuCustomContent(content.value)
     }
 
-    class SubheaderContext : MenuEntryContext {
+    class SubheaderContext {
         val text = ComponentProperty("")
-        override fun build(): MenuEntry = MenuSubheader(text.value)
+        fun build() = MenuSubheader(text.value)
     }
 
-    class DividerContext : MenuEntryContext {
-        override fun build(): MenuEntry = MenuDivider()
+    class DividerContext {
+        fun build() = MenuDivider()
     }
 
 

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -169,17 +169,31 @@ open class MenuComponent<E : MenuEntriesContext>(private val entriesContextProvi
         }
 
         private val staticDropdownContainerCss = staticStyle("menu-dropdown-container") {
-            position { relative { } }
+            position(
+                sm = { static },
+                md = { relative { } }
+            )
         }
 
         private val staticDropdownCss = staticStyle("menu-dropdown") {
-            position { absolute { } }
-            minWidth { minContent }
+            position(
+                sm = {
+                    absolute {
+                        left { "0px" }
+                    }
+                },
+                md = { absolute { } }
+            )
+            width(
+                sm = { "100%" },
+                md = { minContent }
+            )
             zIndex { "100" }
 
             background { color { neutral } }
             radius { "6px" }
             paddings { vertical { smaller } }
+            overflow { hidden }
 
             boxShadow { raised }
 

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -12,7 +12,6 @@ import dev.fritz2.styling.theme.Icons
 import dev.fritz2.styling.theme.Theme
 import kotlinx.browser.document
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import org.w3c.dom.events.MouseEvent
@@ -265,7 +264,6 @@ open class MenuComponent<E : MenuEntriesContext>(private val entriesContextProvi
 
     private fun RenderContext.listenToWindowEvents(dropdownId: String) {
         Window.clicks.events
-            .drop(1) // filter first event so the dropdown does not get closed imediately
             .filter { event ->
                 val dropdownElement = document.getElementById(dropdownId)
                 dropdownElement?.let {
@@ -502,7 +500,9 @@ data class MenuSubheader(
         prefix: String
     ) {
         context.apply {
-            h5(baseClass = staticMenuEntryCss.name) { +text }
+            (::h5.styled(baseClass = staticMenuEntryCss) {
+                css("white-space: nowrap")
+            }) { +text }
         }
     }
 }

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -164,7 +164,7 @@ open class MenuComponent<E : MenuEntriesContext>(private val entriesContextProvi
 
     companion object {
         private val staticContainerCss = staticStyle("menu-container") {
-            display { inlineBlock }
+            display { inlineFlex }
             width { minContent }
         }
 
@@ -228,7 +228,7 @@ open class MenuComponent<E : MenuEntriesContext>(private val entriesContextProvi
         val placement = placement.value.invoke(menuStyles.placements)
 
         context.apply {
-            flexBox(baseClass = staticContainerCss, styling = placement.containerLayout) {
+            box(baseClass = staticContainerCss, styling = placement.containerLayout) {
 
                 box(id = "menu-toggle-${uniqueId()}") {
                     toggle.value(this)

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -87,7 +87,8 @@ val menuStyles = object : MenuStyles {
 }
 
 
-class MenuComponent {
+@ComponentMarker
+open class MenuComponent : Component<Unit> {
 
     companion object {
         private val staticContainerCss = staticStyle("menu-container") {
@@ -124,16 +125,17 @@ class MenuComponent {
     val items = ComponentProperty<(RenderContext.() -> Unit)?>(value = null)
     val placement = ComponentProperty<MenuPlacements.() -> MenuPlacement> { bottom }
 
-    fun render(
-        styling: BasicParams.() -> Unit,
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
         baseClass: StyleClass?,
-        id: String,
-        prefix: String,
-        renderContext: RenderContext,
+        id: String?,
+        prefix: String
     ) {
+        val uniqueId = "menu-dropdown-${uniqueId()}"
         val placement = placement.value.invoke(menuStyles.placements)
 
-        renderContext.apply {
+        context.apply {
             flexBox(baseClass = staticContainerCss, styling = placement.containerLayout) {
 
                 box(id = "menu-toggle-${uniqueId()}") {
@@ -145,14 +147,15 @@ class MenuComponent {
                     visibilityStore.data.render { visible ->
                         if (visible) {
                             box(
-                                styling = styling + placement.dropdownStyle,
+                                // TODO: Fix styling
+                                styling = /*styling + */placement.dropdownStyle,
                                 baseClass = baseClass?.let { it + staticDropdownCss } ?: staticDropdownCss,
-                                id = id,
+                                id = uniqueId,
                                 prefix = prefix
                             ) {
                                 items.value?.invoke(this)
                             }
-                            listenToWindowEvents(id)
+                            listenToWindowEvents(uniqueId)
                         } else {
                             box { /* just an empty placeholder */ }
                         }
@@ -188,10 +191,11 @@ fun RenderContext.menu(
     build: MenuComponent.() -> Unit,
 ) = MenuComponent()
     .apply(build)
-    .render(styling, baseClass, id, prefix, this)
+    .render(this, styling, baseClass, id, prefix)
 
 
-class MenuItemComponent : EventProperties<HTMLDivElement> by EventMixin() {
+@ComponentMarker
+open class MenuItemComponent : Component<Unit>, EventProperties<HTMLDivElement> by EventMixin() {
 
     companion object {
         private val menuItemStyle: Style<FlexParams> = {
@@ -207,16 +211,17 @@ class MenuItemComponent : EventProperties<HTMLDivElement> by EventMixin() {
     val leftIcon = ComponentProperty<(Icons.() -> IconDefinition)?>(value = null)
     val rightIcon = ComponentProperty<(Icons.() -> IconDefinition)?>(value = null)
 
-    fun render(
-        styling: BasicParams.() -> Unit,
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
         baseClass: StyleClass?,
         id: String?,
-        prefix: String,
-        renderContext: RenderContext,
+        prefix: String
     ) {
-        renderContext.apply {
+        context.apply {
             flexBox(
-                styling = styling + menuItemStyle,
+                // TODO: Fix styling
+                styling = /*styling + */menuItemStyle,
                 baseClass = baseClass?.let { it + staticMenuEntryCss } ?: staticMenuEntryCss,
                 id = id,
                 prefix = prefix,
@@ -257,32 +262,34 @@ fun RenderContext.menuItem(
             }
         }
 
-    component.render(styling, baseClass, id, prefix, this)
+    component.render(this, styling, baseClass, id, prefix)
     return clickListener!!
 }
 
 
-class MenuGroupComponent {
+@ComponentMarker
+open class MenuGroupComponent : Component<Unit> {
     val title = ComponentProperty<String?>(value = null)
     val items = ComponentProperty<(RenderContext.() -> Unit)?>(value = null)
 
-    fun render(
-        styling: BasicParams.() -> Unit,
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
         baseClass: StyleClass?,
         id: String?,
-        prefix: String,
-        renderContext: RenderContext,
+        prefix: String
     ) {
-        renderContext.apply {
+        context.apply {
             stackUp(
-                styling = styling,
+                // TODO: Fix styling
+                //styling = styling,
                 baseClass = baseClass,
                 id = id,
                 prefix = prefix
             ) {
                 spacing { none }
                 items {
-                    title.value?.let {
+                    this@MenuGroupComponent.title.value?.let {
                         h5(baseClass = staticMenuEntryCss.name) { +it }
                     }
                     this@MenuGroupComponent.items.value?.invoke(this)
@@ -300,7 +307,7 @@ fun RenderContext.menuGroup(
     build: MenuGroupComponent.() -> Unit,
 ) = MenuGroupComponent()
     .apply(build)
-    .render(styling, baseClass, id, prefix, this)
+    .render(this, styling, baseClass, id, prefix)
 
 fun RenderContext.checkboxMenuGroup(
     styling: BasicParams.() -> Unit = {},

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -67,7 +67,7 @@ val menuStyles = object : MenuStyles {
 private val staticMenuEntryCss = staticStyle("menu-entry") {
     width { "100%" }
     paddings {
-        horizontal { small }
+        horizontal { normal }
         vertical { smaller }
     }
     radius { "6px" }
@@ -215,7 +215,7 @@ open class MenuComponent<E : MenuEntriesContext>(private val entriesContextProvi
             variant { outline }
         }
     }
-    val items = ComponentProperty<(E.() -> Unit)?>(value = null)
+    val entries = ComponentProperty<(E.() -> Unit)?>(value = null)
     val placement = ComponentProperty<MenuPlacements.() -> MenuPlacement> { bottom }
 
     override fun render(
@@ -266,7 +266,7 @@ open class MenuComponent<E : MenuEntriesContext>(private val entriesContextProvi
             id = uniqueDropdownId,
             prefix = prefix
         ) {
-            items.value?.let {
+            entries.value?.let {
                 val entriesContext = entriesContextProvider().apply(it)
                 entriesContext.entries.forEach { entry ->
                     entry.render(context = this, styling = {}, StyleClass.None, id = null, prefix)

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -284,6 +284,13 @@ fun RenderContext.menu(
     .render(this, styling, baseClass, id, prefix)
 
 
+/**
+ * A special [Component] that can be used as an entry in a [MenuComponent].
+ *
+ * @see MenuItemComponent
+ * @see MenuDividerComponent
+ * @see MenuSubheaderComponent
+ */
 typealias MenuEntryComponent = Component<Unit>
 
 /**
@@ -335,7 +342,17 @@ open class MenuEntriesContext {
 }
 
 
-class MenuItemComponent : MenuEntryComponent {
+/**
+ * This class combines the _configuration_ and the core rendering of a MenuItemComponent.
+ *
+ * A MenuItem is a special kind of button consisting of a label and an optional icon used in dropdown menus.
+ * Just like a regular button it is clickable and can be enabled/disabled.
+ *
+ * It can be configured with an _icon_, a _text_ and a boolean-[Flow] to determine whether the item is enabled.
+ *
+ * @see MenuItemComponent
+ */
+open class MenuItemComponent : MenuEntryComponent {
 
     companion object {
         private val staticMenuItemCss = staticStyle("menu-item") {
@@ -403,7 +420,13 @@ class MenuItemComponent : MenuEntryComponent {
     }
 }
 
-class CustomMenuItemComponent : MenuEntryComponent {
+/**
+ * This class combines the _configuration_ and the core rendering of a CustomMenuItemComponent.
+ *
+ * A custom menu item can be any fritz2 component. The component simply wraps any layout in a container and renders it
+ * to the menu.
+ */
+open class CustomMenuItemComponent : MenuEntryComponent {
 
     val content = ComponentProperty<RenderContext.() -> Unit> { }
 
@@ -430,7 +453,13 @@ class CustomMenuItemComponent : MenuEntryComponent {
     }
 }
 
-class MenuSubheaderComponent : MenuEntryComponent {
+/**
+ * This class combines the _configuration_ and the core rendering of a MenuSubheaderComponent.
+ *
+ * A subheader can be used to introduce a group of menu entries and separate them from the entries above.
+ * It simply is a styled header consisting of a static _text_.
+ */
+open class MenuSubheaderComponent : MenuEntryComponent {
 
     val text = ComponentProperty("")
 
@@ -449,7 +478,13 @@ class MenuSubheaderComponent : MenuEntryComponent {
     }
 }
 
-class MenuDividerComponent : MenuEntryComponent {
+/**
+ * This class combines the _configuration_ and the core rendering of a MenuSubheaderComponent.
+ *
+ * Similar to a subheader a divider can be used to group entries together. Compared to a subheader a divider displays
+ * a thin line rather than text.
+ */
+open class MenuDividerComponent : MenuEntryComponent {
 
     private val menuDividerCss = style("menu-divider") {
         width { "100%" }

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -12,16 +12,22 @@ import dev.fritz2.styling.theme.Icons
 
 
 private val menuItemCss = staticStyle("menu-item") {
-    margins {
-        bottom { normal }
+    width { "100%" }
+    paddings {
+        vertical { smaller }
     }
+    radius { "6px" }
 }
 
-private val menuOptionCss: Style<BasicParams> = {
-    margins {
-        top { smaller }
-        bottom { smaller }
-    }
+private val menuDividerCss = staticStyle("menu-divider") {
+    width { "100%" }
+    height { "1px" }
+    margins { vertical { smaller } }
+    background { color { lighterGray } }
+}
+
+private val menuOptionStyle: Style<BasicParams> = {
+    margins { vertical { smaller } }
 }
 
 
@@ -36,13 +42,15 @@ class MenuComponent {
             position { absolute { } }
             zIndex { "100" }
             radius { "6px" }
-            background { color { lightestGray } }
+            background { color { base } }
 
-            padding { small }
+            paddings {
+                horizontal { small }
+                bottom { small }
+            }
             minWidth { "20vw" }
 
-            // TODO: Use builtin box-shadow property
-            css(" box-shadow: rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px;")
+            boxShadow { raised }
         }
 
         class VisibilityStore : RootStore<Boolean>(false) {
@@ -107,6 +115,18 @@ fun RenderContext.menu(
 
 
 class MenuItemComponent {
+    companion object {
+        private val menuContainerStyle: Style<FlexParams> = {
+            alignItems { AlignItemsValues.center }
+            hover {
+                background {
+                    color { lightestGray }
+                }
+                css("filter: brightness(90%);")
+            }
+        }
+    }
+
     val label = ComponentProperty<String?>(value = null)
     val leftIcon = ComponentProperty<(Icons.() -> IconDefinition)?>(value = null)
     val rightIcon = ComponentProperty<(Icons.() -> IconDefinition)?>(value = null)
@@ -120,9 +140,7 @@ class MenuItemComponent {
     ) {
         renderContext.apply {
             flexBox(
-                styling = styling + {
-                    alignItems { center }
-                },
+                styling = styling + menuContainerStyle,
                 baseClass = menuItemCss + baseClass,
                 id = id,
                 prefix = prefix,
@@ -154,15 +172,6 @@ fun RenderContext.menuItem(
     .render(styling, baseClass, id, prefix, this)
 
 
-fun RenderContext.menuDivider() {
-    box(baseClass = menuItemCss, styling = {
-        width { "100%" }
-        height { "1px" }
-        background { color { lighterGray } }
-    }) { }
-}
-
-
 class MenuGroupComponent {
     val title = ComponentProperty<String?>(value = null)
     val titleStyle = ComponentProperty<Style<BasicParams>> { }
@@ -185,7 +194,9 @@ class MenuGroupComponent {
                 spacing { none }
                 items {
                     title.value?.let {
-                        (::h6.styled(styling = titleStyle.value, baseClass = menuItemCss)) { +it }
+                        (::h6.styled(styling = titleStyle.value + {
+                            margins { bottom { smaller } }
+                        })) { +it }
                     }
                     this@MenuGroupComponent.items.value?.invoke(this)
                 }
@@ -218,7 +229,7 @@ fun RenderContext.menuCheckboxGroup(
         titleStyle { margins { bottom { smaller } } }
         items {
             checkboxGroup(items = options, store = store) {
-                itemStyle(menuOptionCss)
+                itemStyle(menuOptionStyle)
             }
         }
     }
@@ -238,8 +249,11 @@ fun RenderContext.menuRadioGroup(
         titleStyle { margins { bottom { smaller } } }
         items {
             radioGroup(items = options, store = store) {
-                itemStyle(menuOptionCss)
+                itemStyle(menuOptionStyle)
             }
         }
     }
 }
+
+
+fun RenderContext.menuDivider() = box(baseClass = menuDividerCss) { }

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -142,7 +142,7 @@ open class MenuComponent : Component<Unit> {
             )
             width(
                 sm = { "100%" },
-                md = { minContent }
+                md = { maxContent }
             )
             zIndex { overlay }
 

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -137,28 +137,26 @@ open class MenuComponent : Component<Unit> {
 
         private val staticDropdownCss = staticStyle("menu-dropdown") {
             position(
-                sm = {
-                    absolute {
-                        left { "0px" }
-                    }
-                },
+                sm = { absolute { left { "0px" } } },
                 md = { absolute { } }
             )
             width(
                 sm = { "100%" },
                 md = { minContent }
             )
-            zIndex { "100" }
+            zIndex { overlay }
 
             background { color { neutral } }
             radius { "6px" }
             paddings { vertical { smaller } }
-            overflow { hidden }
+            overflow(
+                sm = { hidden },
+                md = { visible }
+            )
 
             boxShadow { raised }
 
             // FIXME: Animation not working
-            // fade-in-animation
             //opacity { "1" }
             //css("transition: opacity 1s ease-in-out;")
         }
@@ -334,7 +332,6 @@ open class MenuEntriesContext {
     val entries: List<MenuEntry>
         get() = _entries.toList()
 
-    @Suppress("MemberVisibilityCanBePrivate")
     fun addEntry(entry: MenuEntry) {
         _entries += entry
     }

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -228,7 +228,7 @@ open class MenuComponent<E : MenuEntriesContext>(private val entriesContextProvi
         val placement = placement.value.invoke(menuStyles.placements)
 
         context.apply {
-            box(baseClass = staticContainerCss, styling = placement.containerLayout) {
+            flexBox(baseClass = staticContainerCss, styling = placement.containerLayout) {
 
                 box(id = "menu-toggle-${uniqueId()}") {
                     toggle.value(this)

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -101,11 +101,12 @@ open class MenuComponent : Component<Unit> {
 
         private val staticDropdownCss = staticStyle("menu-dropdown") {
             position { absolute { } }
-            zIndex { "100" }
-            radius { "6px" }
-            background { color { base } }
-
             minWidth { minContent }
+            zIndex { "100" }
+
+            background { color { base } }
+            radius { "6px" }
+            paddings { vertical { smaller } }
 
             boxShadow { raised }
 

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -7,6 +7,7 @@ import dev.fritz2.identification.uniqueId
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.*
 import dev.fritz2.styling.staticStyle
+import dev.fritz2.styling.style
 import dev.fritz2.styling.theme.IconDefinition
 import dev.fritz2.styling.theme.Icons
 import dev.fritz2.styling.theme.Theme
@@ -144,17 +145,12 @@ open class MenuComponent : Component<Unit> {
                 sm = { "100%" },
                 md = { maxContent }
             )
-            zIndex { overlay }
 
-            background { color { neutral } }
             radius { "6px" }
-            paddings { vertical { smaller } }
             overflow(
                 sm = { hidden },
                 md = { visible }
             )
-
-            boxShadow { raised }
 
             // FIXME: Animation not working
             //opacity { "1" }
@@ -162,9 +158,17 @@ open class MenuComponent : Component<Unit> {
         }
     }
 
+    private val dropdownStyle: Style<BasicParams> = {
+        paddings { vertical { smaller } }
+        zIndex { overlay }
+        boxShadow { raised }
+        background { color { neutral } }
+    }
+
+
     private val visibilityStore = object : RootStore<Boolean>(false) {
-        val show = handle<Unit> { _, _ -> true }
-        val dismiss = handle<Unit> { _, _ -> false }
+        val show = handle { true }
+        val dismiss = handle { false }
     }
 
     val toggle = ComponentProperty<RenderContext.() -> Unit> {
@@ -219,6 +223,7 @@ open class MenuComponent : Component<Unit> {
             styling = { this as BoxParams
                 styling()
                 placement.dropdownStyle()
+                dropdownStyle()
             },
             baseClass = baseClass + staticDropdownCss,
             id = uniqueDropdownId,
@@ -369,23 +374,22 @@ data class MenuItem(
         private val staticMenuItemCss = staticStyle("menu-item") {
             width { "100%" }
             alignItems { center }
-
             radius { "6px" }
         }
+    }
 
-        private val menuItemActiveStyle: Style<FlexParams> = {
-            hover {
-                background { color { gray300 } }
-                css("filter: brightness(90%);")
-            }
+    private val menuItemActiveStyle: Style<FlexParams> = {
+        hover {
+            background { color { gray200 } }
+            css("filter: brightness(90%);")
         }
+    }
 
-        private val menuItemButtonVariant: Style<BasicParams> = {
-            fontWeight { normal }
-            color { Theme().fontColor }
-            focus {
-                boxShadow { none }
-            }
+    private val menuItemButtonVariant: Style<BasicParams> = {
+        fontWeight { normal }
+        color { Theme().fontColor }
+        focus {
+            boxShadow { none }
         }
     }
 
@@ -411,7 +415,7 @@ data class MenuItem(
                     baseClass = staticMenuItemCss,
                     styling = if (enabled) menuItemActiveStyle else ({ })
                 ) {
-                    clickButton() {
+                    clickButton {
                         icon?.let {
                             icon { def(it) }
                         }
@@ -471,13 +475,11 @@ data class MenuSubheader(
 
 class MenuDivider : MenuEntry {
 
-    companion object {
-        private val staticMenuDividerCss = staticStyle("menu-divider") {
-            width { "100%" }
-            height { "1px" }
-            margins { vertical { smaller } }
-            background { color { gray300 } }
-        }
+    private val menuDividerCss = style("menu-divider") {
+        width { "100%" }
+        height { "1px" }
+        margins { vertical { smaller } }
+        background { color { gray300 } }
     }
 
     override fun render(
@@ -488,7 +490,7 @@ class MenuDivider : MenuEntry {
         prefix: String
     ) {
         context.apply {
-            box(baseClass = staticMenuDividerCss) { }
+            box(baseClass = menuDividerCss) { }
         }
     }
 }

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -1,0 +1,169 @@
+package dev.fritz2.components
+
+import dev.fritz2.binding.RootStore
+import dev.fritz2.binding.SimpleHandler
+import dev.fritz2.binding.Store
+import dev.fritz2.dom.html.RenderContext
+import dev.fritz2.styling.StyleClass
+import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.Style
+import dev.fritz2.styling.params.plus
+import dev.fritz2.styling.params.styled
+import dev.fritz2.styling.theme.IconDefinition
+import dev.fritz2.styling.theme.Icons
+import dev.fritz2.styling.theme.Theme
+import kotlinx.coroutines.flow.flowOf
+
+class MenuComponent {
+
+    companion object {
+        private val menuContainerCss: Style<BasicParams> = {
+            position { relative { } }
+            display { inlineBlock }
+        }
+
+        private val menuInnerCss: Style<BasicParams> = {
+            position { absolute { } }
+            zIndex { "100" }
+            radius { "6px" }
+            background { color { lightestGray } }
+
+            padding { normal }
+            minWidth { "20vw" }
+
+            css(" box-shadow: rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px;")
+        }
+    }
+
+    val items = ComponentProperty<(RenderContext.() -> Unit)?>(value = null)
+    internal val visible = ComponentProperty(value = flowOf(false))
+
+    fun render(renderContext: RenderContext) {
+        renderContext.apply {
+            box(styling = menuContainerCss) {
+                visible.value.render {
+                    if (it)
+                        box(styling = menuInnerCss) {
+                            items.value?.invoke(this)
+                        }
+                    else
+                        box { }
+                }
+            }
+        }
+    }
+}
+
+fun RenderContext.menu(
+    styling: BasicParams.() -> Unit = {},
+    baseClass: StyleClass? = null,
+    id: String? = null,
+    prefix: String = "alert",
+    build: MenuComponent.() -> Unit,
+): SimpleHandler<Unit> {
+
+    val visibilityStore = object : RootStore<Boolean>(false) {
+        val show = handle<Unit> { _, _ -> true }
+    }
+
+    // TODO: Pass down styling params
+    MenuComponent().apply(build + {
+        visible(visibilityStore.data)
+    }).render(this)
+
+    return visibilityStore.show
+}
+
+
+class MenuItemComponent {
+    val label = ComponentProperty<String?>(value = null)
+    val leftIcon = ComponentProperty<(Icons.() -> IconDefinition)?>(value = null)
+    val rightIcon = ComponentProperty<(Icons.() -> IconDefinition)?>(value = null)
+
+    fun render(renderContext: RenderContext) {
+        renderContext.apply {
+            lineUp {
+                items {
+                    leftIcon.value?.invoke(Theme().icons)
+                    label.value?.let {
+                        (::h6.styled {
+                            // TODO: Item styling
+                        }) { +it }
+                    }
+                    rightIcon.value?.invoke(Theme().icons)
+                }
+            }
+        }
+    }
+}
+
+fun RenderContext.menuItem(
+    styling: BasicParams.() -> Unit = {},
+    baseClass: StyleClass? = null,
+    id: String? = null,
+    prefix: String = "menu-item",
+    build: MenuItemComponent.() -> Unit,
+) = MenuItemComponent().apply(build).render(this)
+
+
+class MenuItemGroupComponent {
+    val title = ComponentProperty<String?>(value = null)
+    val items = ComponentProperty<(RenderContext.() -> Unit)?>(value = null)
+
+    fun render(renderContext: RenderContext) {
+        renderContext.apply {
+            stackUp {
+                items {
+                    title.value?.let {
+                        (::h6.styled {
+                            // TODO: Group header style
+                        }) { +it }
+                    }
+                    this@MenuItemGroupComponent.items.value?.invoke(this)
+                }
+            }
+        }
+    }
+}
+
+fun RenderContext.menuGroup(
+    styling: BasicParams.() -> Unit = {},
+    baseClass: StyleClass? = null,
+    id: String? = null,
+    prefix: String = "menu-item-group",
+    build: MenuItemGroupComponent.() -> Unit,
+) = MenuItemGroupComponent().apply(build).render(this)
+
+fun RenderContext.menuCheckboxGroup(
+    styling: BasicParams.() -> Unit = {},
+    baseClass: StyleClass? = null,
+    id: String? = null,
+    prefix: String = "menu-checkbox-group",
+    title: String,
+    options: List<String>,
+    store: Store<List<String>>? = null,
+) {
+    menuGroup {
+        title(title)
+        items {
+            checkboxGroup(items = options, store = store)
+        }
+    }
+}
+
+fun RenderContext.menuRadioGroup(
+    styling: BasicParams.() -> Unit = {},
+    baseClass: StyleClass? = null,
+    id: String? = null,
+    prefix: String = "menu-radio-group",
+    title: String,
+    options: List<String>,
+    store: Store<String>? = null,
+) {
+    menuGroup {
+        title(title)
+        items {
+            radioGroup(items = options, store = store)
+        }
+    }
+}

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -429,9 +429,12 @@ data class MenuItem(
             }
         }
 
-        private val menuItemButtonStyle: Style<BasicParams> = {
+        private val menuItemButtonVariant: Style<BasicParams> = {
             fontWeight { normal }
             color { Theme().fontColor }
+            focus {
+                boxShadow { none }
+            }
         }
     }
 
@@ -457,11 +460,11 @@ data class MenuItem(
                     baseClass = staticMenuItemCss,
                     styling = if (enabled) menuItemActiveStyle else ({ })
                 ) {
-                    clickButton(styling = menuItemButtonStyle) {
+                    clickButton() {
                         icon?.let {
                             icon { def(it) }
                         }
-                        variant { ghost }
+                        variant { menuItemButtonVariant }
                         text(text)
                         disabled(!enabled)
                     }.map { it } handledBy clickStore.forwardMouseEvents

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -19,7 +19,6 @@ class MenuComponent {
     companion object {
         private val menuContainerCss: Style<BasicParams> = {
             position { relative { } }
-            display { inlineBlock }
         }
 
         private val menuInnerCss: Style<BasicParams> = {
@@ -40,10 +39,10 @@ class MenuComponent {
 
     fun render(renderContext: RenderContext) {
         renderContext.apply {
-            box(styling = menuContainerCss) {
+            box(styling = menuContainerCss, prefix = "menu-container") {
                 visible.value.render {
                     if (it)
-                        box(styling = menuInnerCss) {
+                        box(styling = menuInnerCss, prefix = "menu-inner") {
                             items.value?.invoke(this)
                         }
                     else

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -109,7 +109,12 @@ open class MenuComponent : Component<Unit> {
         val dismiss = handle<Unit> { _, _ -> false }
     }
 
-    val toggle = ComponentProperty<RenderContext.() -> Unit> { }
+    val toggle = ComponentProperty<RenderContext.() -> Unit> {
+        pushButton {
+            icon { fromTheme { menu } }
+            variant { outline }
+        }
+    }
     val items = ComponentProperty<(MenuEntriesContext.() -> Unit)?>(value = null)
     val placement = ComponentProperty<MenuPlacements.() -> MenuPlacement> { bottom }
 

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -11,10 +11,9 @@ import dev.fritz2.styling.theme.IconDefinition
 import dev.fritz2.styling.theme.Icons
 import dev.fritz2.styling.theme.Theme
 import kotlinx.browser.document
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.*
 import org.w3c.dom.events.MouseEvent
+import kotlin.js.Date
 
 
 // TODO: Move styles into theme
@@ -263,8 +262,14 @@ open class MenuComponent<E : MenuEntriesContext>(private val entriesContextProvi
     }
 
     private fun RenderContext.listenToWindowEvents(dropdownId: String) {
+        // delay listening so the dropdown is not closed immediately:
+        val startListeningMillis = Date.now() + 200
+
         Window.clicks.events
             .filter { event ->
+                if (Date.now() < startListeningMillis)
+                    return@filter false
+
                 val dropdownElement = document.getElementById(dropdownId)
                 dropdownElement?.let {
                     val bounds = it.getBoundingClientRect()

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -100,7 +100,7 @@ class MenuComponent {
                 horizontal { small }
                 bottom { small }
             }
-            minWidth { "20vw" }
+            minWidth { minContent }
 
             boxShadow { raised }
 
@@ -227,6 +227,7 @@ class MenuItemComponent : EventProperties<HTMLDivElement> by EventMixin() {
                 label.value?.let {
                     (::label.styled {
                         margins { left { tiny } }
+                        css("white-space: nowrap")
                     }) { +it }
                 }
                 rightIcon.value?.let {

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -164,6 +164,7 @@ open class MenuComponent<E : MenuEntriesContext>(private val entriesContextProvi
 
     companion object {
         private val staticContainerCss = staticStyle("menu-container") {
+            display { inlineBlock }
             width { minContent }
         }
 
@@ -213,7 +214,7 @@ open class MenuComponent<E : MenuEntriesContext>(private val entriesContextProvi
         val placement = placement.value.invoke(menuStyles.placements)
 
         context.apply {
-            flexBox(baseClass = staticContainerCss, styling = placement.containerLayout) {
+            box(baseClass = staticContainerCss, styling = placement.containerLayout) {
 
                 box(id = "menu-toggle-${uniqueId()}") {
                     toggle.value(this)

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -9,6 +9,7 @@ import dev.fritz2.identification.uniqueId
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.*
 import dev.fritz2.styling.staticStyle
+import dev.fritz2.styling.style
 import dev.fritz2.styling.theme.IconDefinition
 import dev.fritz2.styling.theme.Icons
 import kotlinx.browser.document
@@ -31,7 +32,7 @@ private val staticMenuDividerCss = staticStyle("menu-divider") {
     width { "100%" }
     height { "1px" }
     margins { vertical { smaller } }
-    background { color { lighterGray } }
+    background { color { gray300 } }
 }
 
 private val menuOptionStyle: Style<BasicParams> = {
@@ -104,7 +105,7 @@ open class MenuComponent : Component<Unit> {
             minWidth { minContent }
             zIndex { "100" }
 
-            background { color { base } }
+            background { color { neutral } }
             radius { "6px" }
             paddings { vertical { smaller } }
 
@@ -129,7 +130,7 @@ open class MenuComponent : Component<Unit> {
     override fun render(
         context: RenderContext,
         styling: BoxParams.() -> Unit,
-        baseClass: StyleClass?,
+        baseClass: StyleClass,
         id: String?,
         prefix: String
     ) {
@@ -150,7 +151,7 @@ open class MenuComponent : Component<Unit> {
                             box(
                                 // TODO: Fix styling
                                 styling = /*styling + */placement.dropdownStyle,
-                                baseClass = baseClass?.let { it + staticDropdownCss } ?: staticDropdownCss,
+                                baseClass = baseClass + staticDropdownCss,
                                 id = uniqueId,
                                 prefix = prefix
                             ) {
@@ -186,7 +187,7 @@ open class MenuComponent : Component<Unit> {
 
 fun RenderContext.menu(
     styling: BasicParams.() -> Unit = {},
-    baseClass: StyleClass? = null,
+    baseClass: StyleClass = StyleClass.None,
     id: String = "menu-dropdown-${uniqueId()}",
     prefix: String = "menu-dropdown",
     build: MenuComponent.() -> Unit,
@@ -202,7 +203,7 @@ open class MenuItemComponent : Component<Unit>, EventProperties<HTMLDivElement> 
         private val menuItemStyle: Style<FlexParams> = {
             alignItems { center }
             hover {
-                background { color { lightestGray } }
+                background { color { gray300 } }
                 css("filter: brightness(90%);")
             }
         }
@@ -215,7 +216,7 @@ open class MenuItemComponent : Component<Unit>, EventProperties<HTMLDivElement> 
     override fun render(
         context: RenderContext,
         styling: BoxParams.() -> Unit,
-        baseClass: StyleClass?,
+        baseClass: StyleClass,
         id: String?,
         prefix: String
     ) {
@@ -223,7 +224,7 @@ open class MenuItemComponent : Component<Unit>, EventProperties<HTMLDivElement> 
             flexBox(
                 // TODO: Fix styling
                 styling = /*styling + */menuItemStyle,
-                baseClass = baseClass?.let { it + staticMenuEntryCss } ?: staticMenuEntryCss,
+                baseClass = baseClass + staticMenuEntryCss,
                 id = id,
                 prefix = prefix,
             ) {
@@ -248,7 +249,7 @@ open class MenuItemComponent : Component<Unit>, EventProperties<HTMLDivElement> 
 
 fun RenderContext.menuItem(
     styling: BasicParams.() -> Unit = {},
-    baseClass: StyleClass? = null,
+    baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "menu-item",
     build: MenuItemComponent.() -> Unit,
@@ -276,7 +277,7 @@ open class MenuGroupComponent : Component<Unit> {
     override fun render(
         context: RenderContext,
         styling: BoxParams.() -> Unit,
-        baseClass: StyleClass?,
+        baseClass: StyleClass,
         id: String?,
         prefix: String
     ) {
@@ -302,7 +303,7 @@ open class MenuGroupComponent : Component<Unit> {
 
 fun RenderContext.menuGroup(
     styling: BasicParams.() -> Unit = {},
-    baseClass: StyleClass? = null,
+    baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "menu-item-group",
     build: MenuGroupComponent.() -> Unit,
@@ -312,7 +313,7 @@ fun RenderContext.menuGroup(
 
 fun RenderContext.checkboxMenuGroup(
     styling: BasicParams.() -> Unit = {},
-    baseClass: StyleClass? = null,
+    baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "menu-checkbox-group",
     title: String,
@@ -338,7 +339,7 @@ fun RenderContext.checkboxMenuGroup(
 
 fun RenderContext.radioMenuGroup(
     styling: BasicParams.() -> Unit = {},
-    baseClass: StyleClass? = null,
+    baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "menu-radio-group",
     title: String,

--- a/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/menu/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -18,9 +18,6 @@ import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.events.MouseEvent
 
 
-private const val menuToggleIdPrefix = "menu-toggle"
-
-
 private val menuEntryCss = staticStyle("menu-item") {
     width { "100%" }
     paddings {
@@ -82,52 +79,6 @@ val menuPlacements = object : MenuPlacements {
 }
 
 
-private object GlobalDropdownStore : RootStore<List<String>>(listOf()) {
-
-    private var listeningToWindowEvents = false
-
-    val register = handle<String> { currentlyOpen, id -> listOf(id) + currentlyOpen.toMutableList() }
-
-    val determineChildrenToDismiss = handleAndEmit<MouseEvent, String> { currentlyOpen, mouseEvent ->
-        val newList = currentlyOpen.toMutableList()
-        for (id in currentlyOpen) {
-            if (isClickInsideElement(mouseEvent, id)) {
-                break
-            } else {
-                newList -= id
-                emit(id) // dropdown with id should be closed
-            }
-        }
-        newList
-    }
-
-    private fun isClickInsideElement(event: MouseEvent, elementId: String): Boolean {
-        document.getElementById(elementId)?.let {
-            val bounds = it.getBoundingClientRect()
-            return event.x >= bounds.left
-                    && event.x <= bounds.right
-                    && event.y >= bounds.top
-                    && event.y <= bounds.bottom
-        }
-        return false
-    }
-
-    fun listenToWindowEvents(renderContext: RenderContext) {
-        if (!listeningToWindowEvents) {
-            renderContext.apply {
-                Window.clicks.events.filter { event ->
-                    document.elementFromPoint(event.x, event.y)?.let { element ->
-                        return@filter element.closest("[id^='$menuToggleIdPrefix']") == null
-                    }
-                    false
-                } handledBy determineChildrenToDismiss
-            }
-            listeningToWindowEvents = true
-        }
-    }
-}
-
-
 class MenuComponent {
 
     companion object {
@@ -145,7 +96,10 @@ class MenuComponent {
             radius { "6px" }
             background { color { base } }
 
-            paddings { horizontal { small } }
+            paddings {
+                horizontal { small }
+                bottom { small }
+            }
             minWidth { minContent }
 
             boxShadow { raised }
@@ -158,10 +112,7 @@ class MenuComponent {
     }
 
     private val visibilityStore = object : RootStore<Boolean>(false) {
-        val show = handleAndEmit<Unit, Unit> { _, _ ->
-            emit(Unit)
-            true
-        }
+        val show = handle<Unit> { _, _ -> true }
         val dismiss = handle<Unit> { _, _ -> false }
     }
 
@@ -179,15 +130,11 @@ class MenuComponent {
         val placement = placement.value.invoke(menuPlacements)
 
         renderContext.apply {
-
-            // register dropdown so it can be managed by the globalDropdownStore:
-            visibilityStore.show.map { id } handledBy GlobalDropdownStore.register
-            GlobalDropdownStore.listenToWindowEvents(this)
-
             flexBox(baseClass = menuContainerCss, styling = placement.containerLayout) {
 
-                box(id = "$menuToggleIdPrefix-${uniqueId()}") {
+                box(prefix = "menu-toggle") {
                     toggle.value(this)
+                    // TODO: Close menu when clicking outside
                     clicks.events.map { } handledBy visibilityStore.show
                 }
 
@@ -202,18 +149,31 @@ class MenuComponent {
                             ) {
                                 items.value?.invoke(this)
                             }
-
-                            GlobalDropdownStore.determineChildrenToDismiss
-                                .filter { toClose -> toClose == id }
-                                .map { } handledBy visibilityStore.dismiss
-
+                            handleOutsideClicks(id)
                         } else {
-                            box { }
+                            box { /* just an empty placeholder */ }
                         }
                     }
                 }
             }
         }
+    }
+
+    private fun RenderContext.handleOutsideClicks(menuDropdownId: String) {
+        Window.clicks.events
+            .filter { event ->
+                val dropdownElement = document.getElementById(menuDropdownId)
+                dropdownElement?.let {
+                    val bounds = it.getBoundingClientRect()
+                    // Only handle clicks outside of the menu dropdown
+                    return@filter !(event.x >= bounds.left
+                            && event.x <= bounds.right
+                            && event.y >= bounds.top
+                            && event.y <= bounds.bottom)
+                }
+                false
+            }
+            .map {  } handledBy visibilityStore.dismiss
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,8 @@ rootProject.name = "fritz2-incubator"
 
 include(
   "demo",
-  "datatable"
+  "datatable",
+  "menu"
 )
 
 enableFeaturePreview("GRADLE_METADATA")


### PR DESCRIPTION
This PR adds a MenuComonent inspired by the one from the Chakra UI framework.

A menu is a dropdown-like overlay that can contain a number of menu items that can be grouped together using dividers and subheaders.

Menus can be created via the `menu` factory-method and are always bound to a so-called toggle, i.e. a `clickButton`.

Progress:
- [X] Implement basic menu-components and the root-component itself
- [X] Styling
- [x] `MenuEntryContext` to better scope the factory-methods of the individual sub-components
- [x] KDoc
- [x] Option to disable menu-items
